### PR TITLE
KAI-421 new endpoint for transformation config

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -132,6 +132,19 @@ group by "customer_id" having count(*) > 2
 """
 )
 
+tr_config_prompt = PromptTemplate.from_template(
+    """
+Answer the user query.
+
+{format_instructions}
+
+Based on the conversation history between Human and AI, create a SQL transformation name (max 8 words), 
+description (max 300 characters) and output table name adhering to Snowflake naming conventions. 
+Focus on describing the user's business intent.
+
+{chat_history}"""
+)
+
 waii_tool_functions = ['get_answer', 'generate_query_only', 'run_query', 'describe_dataset']
 waii_tool_custom_descriptions = {
     'get_answer':  # get_answer and its description

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,12 @@ faiss-cpu
 fastapi~=0.109
 kbcstorage
 langchain==0.1.4
+langchain-core==0.1.22
 langchain-openai==0.0.5
 langchain-community==0.0.19
 langserve[server]==0.0.41
-llama_hub
+llama_hub==0.0.78
+llama-index==0.9.47
 llmonitor~=0.0.51
 openai~=1.10
 pydantic~=1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ SQLAlchemy-Utils~=0.41
 starlette~=0.35
 streamlit
 uvicorn~=0.27
-waii-sdk-py
+waii-sdk-py==1.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi~=0.109
 kbcstorage
 langchain==0.1.4
 langchain-openai==0.0.5
+langchain-community==0.0.19
 langserve[server]==0.0.41
 llama_hub
 llmonitor~=0.0.51


### PR DESCRIPTION
- replicating the behavior in `app.py` (streamlit) in `restapi.py` as a new endpoint
- it lives under `POST /v1/tr_config`, with `chat_history` as the only arg/data